### PR TITLE
Add two ML blogs

### DIFF
--- a/Career Paths/Machine Learning Engineer Career Path/README.md
+++ b/Career Paths/Machine Learning Engineer Career Path/README.md
@@ -360,6 +360,8 @@ During the last few years I collected tons of articles, web apps, reddit threads
 - [TensorFlow official blog](https://medium.com/tensorflow)
 - [KD Nuggets](https://www.kdnuggets.com/)
 - [Incredible Graphic explanations](http://colah.github.io/)
+- [Towards Data Science] (https://towardsdatascience.com)
+- [Machine Learning Mastery] (https://machinelearningmastery.com/blog/)
 
 ### Websites worth taking a look!
 


### PR DESCRIPTION
I think it's worth adding Towards Data Science and Machine Learning Mastery as learning resources in the blog section. The former is useful for having a broader view of the Data Science field, while the latter one explains complex topics in a clear way (it was really useful for my B.Sc. thesis :) )